### PR TITLE
Add config files for running server locally

### DIFF
--- a/proxy_config_atlas.yaml
+++ b/proxy_config_atlas.yaml
@@ -1,0 +1,10 @@
+service_uris:
+  scheduler_rest_api: http://localhost:5000
+  foundations_rest_api: http://localhost:37722
+supported_proxy_methods:
+  - GET
+  - POST
+  - DELETE
+  - PATCH
+  - OPTION
+  - PUT

--- a/route_mapping_atlas.yaml
+++ b/route_mapping_atlas.yaml
@@ -1,0 +1,32 @@
+scheduler_rest_api:
+  - /job_bundle
+  - /job_bundle/<string:job_id>
+  - /queued_jobs
+  - /queued_jobs/<int:position>
+  - /running_jobs
+  - /running_jobs/<string:job_id>
+  - /running_jobs/<string:job_id>/logs
+  - /running_jobs/<string:job_id>/container_id
+  - /completed_jobs
+  - /completed_jobs/<string:job_id>/logs
+  - /failed_jobs
+  - /failed_jobs/<string:job_id>/logs
+  - /workers
+  - /workers/<int:worker_id>
+  - /jobs/<string:job_id>
+foundations_rest_api:
+  - /api/v2beta/projects
+  - /api/v2beta/auth/cli_login
+  - /api/v2beta/auth/logout
+  - /api/v2beta/auth/verify
+  - /api/v2beta/userinfo
+  - /api/v2beta/projects/<string:project_name>/job_listing
+  - /api/v2beta/projects/<string:project_name>/description
+  - /api/v2beta/projects/<string:project_name>/note_listing
+  - /api/v2beta/projects/<string:project_name>/overview_metrics
+  - /api/v2beta/projects/<string:project_name>/job_listing/<string:job_id>/logs
+  - /api/v2beta/upload_to_tensorboard
+  - /api/v2beta/projects/<string:project_name>/job_listing/<string:job_id>/tag/<string:tag_name>
+  - /api/v2beta/projects/<string:project_name>/job_listing/<string:job_id>/tags/<string:tag_name>
+  - /api/v2beta/projects/<string:project_name>/job_listing/<string:job_id>/tags
+  - /api/v2beta/projects/<string:project_name>/job_listing/<string:job_id>


### PR DESCRIPTION
In order to use the auth proxy correctly in the Atlas devenv, we need to launch the auth proxy as a process. This is because the rest api is running locally so the containerized service cannot talk to it as `localhost` will refer to it's own network and not the host machine. 

I'm adding these files so that the auth proxy service can be launched during devenv startup. I don't like the hardcoded ports but that can be fixed later.